### PR TITLE
Refactor Project ownership naming and secure passwords

### DIFF
--- a/synced/synced/Models/Project.cs
+++ b/synced/synced/Models/Project.cs
@@ -5,7 +5,7 @@
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
-        public int Owner { get; set; }
+        public int OwnerId { get; set; }
         public DateTime Start_Date { get; set; }
         public DateTime End_Date { get; set; }
     }

--- a/synced/synced/Models/ProjectCardModel.cs
+++ b/synced/synced/Models/ProjectCardModel.cs
@@ -5,7 +5,7 @@
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
-        public int Owner { get; set; }
+        public int OwnerId { get; set; }
         public int CurrentUserId { get; set; }
     }
 }

--- a/synced/synced/Pages/Dashboard/Projects/ProjectsPage.cshtml
+++ b/synced/synced/Pages/Dashboard/Projects/ProjectsPage.cshtml
@@ -27,7 +27,7 @@
                             id = project.Id,
                             name = project.Name,
                             description = project.Description,
-                            ownerId = project.Owner,
+                            ownerId = project.OwnerId,
                             currentUserId = 1
                         })
                 }

--- a/synced/synced/Pages/Dashboard/Projects/ProjectsPage.cshtml.cs
+++ b/synced/synced/Pages/Dashboard/Projects/ProjectsPage.cshtml.cs
@@ -52,7 +52,7 @@ namespace synced.Pages.Dashboard.Projects
         {
             if (ModelState.IsValid)
             {
-                NewProject.Owner = HttpContext.Session.GetInt32("UserId") ?? 0;
+                NewProject.OwnerId = HttpContext.Session.GetInt32("UserId") ?? 0;
                 OperationResult<bool> result = await _projectService.CreateProject(this.NewProject);
                 if (result.Succeeded)
                 {

--- a/synced/synced/Pages/Shared/Components/ProjectCard/ProjectCard.cshtml
+++ b/synced/synced/Pages/Shared/Components/ProjectCard/ProjectCard.cshtml
@@ -10,8 +10,8 @@
         </div>
         <form id="deleteForm_@Model.Id" method="post" asp-page-handler="delete">
             <input type="hidden" name="ProjectId" value="@Model.Id" />
-            <input type="hidden" name="OwnerId" value="@Model.Owner" />
-            @if (Model.Owner == Model.CurrentUserId)
+            <input type="hidden" name="OwnerId" value="@Model.OwnerId" />
+            @if (Model.OwnerId == Model.CurrentUserId)
             {
                 <button type="submit" class="btn btn-danger w-100">Delete</button>
             }

--- a/synced/synced/Pages/Shared/Components/ProjectCard/ProjectCard.cshtml.cs
+++ b/synced/synced/Pages/Shared/Components/ProjectCard/ProjectCard.cshtml.cs
@@ -12,7 +12,7 @@ namespace synced.ViewComponents
                 Id = id,
                 Name = name,
                 Description = description,
-                Owner = ownerId,
+                OwnerId = ownerId,
                 CurrentUserId = currentUserId
             };
             return View("ProjectCard", model);

--- a/synced/synced_BBL/Dtos/ProjectDto.cs
+++ b/synced/synced_BBL/Dtos/ProjectDto.cs
@@ -18,6 +18,6 @@ namespace synced_BBL.Dtos
 
         public DateOnly End_Date { get;  set; }
 
-        public int Owner { get; set; }
+        public int OwnerId { get; set; }
     }
 }

--- a/synced/synced_BBL/Services/ProjectServices.cs
+++ b/synced/synced_BBL/Services/ProjectServices.cs
@@ -36,7 +36,7 @@ namespace synced_BBL.Services
                     Description = project.Description,
                     Start_Date = project.Start_Date,
                     End_Date = project.End_Date,
-                    Owner = project.Owner
+                    OwnerId = project.OwnerId
                 }).ToList();
 
                 return OperationResult<List<ProjectDto>>.Success(projectDtos);
@@ -57,7 +57,7 @@ namespace synced_BBL.Services
                     projectDto.Description,
                     projectDto.Start_Date,
                     projectDto.End_Date,
-                    projectDto.Owner
+                    projectDto.OwnerId
                 );
 
                 int newProjectId = await _projectRepository.CreateAsync(mappedProject);
@@ -67,7 +67,7 @@ namespace synced_BBL.Services
 
                 ProjectUsers projectUser = ProjectUsers.Create(
                      newProjectId,
-                     mappedProject.Owner,
+                     mappedProject.OwnerId,
                      Roles.admin
                  );
 

--- a/synced/synced_BBL/Services/ProjectUserService.cs
+++ b/synced/synced_BBL/Services/ProjectUserService.cs
@@ -89,7 +89,6 @@ namespace synced_BBL.Services
                         Firstname = pu.User.Firstname,
                         Lastname = pu.User.Lastname,
                         Email = pu.User.Email,
-                        Password = pu.User.Password,
                         Created_at = pu.User.CreatedAt
                     })
                     .ToList();

--- a/synced/synced_DALL/Entities/Project.cs
+++ b/synced/synced_DALL/Entities/Project.cs
@@ -7,11 +7,11 @@
         private string _description;
         private DateOnly _startDate;
         private DateOnly _endDate;
-        private int _owner;
+        private int _ownerId;
 
         // ───────────── Properties ─────────────
         public int Id { get; private set; }
-        public User User { get; private set; }
+        public User Owner { get; private set; }
 
         public string Name
         {
@@ -49,14 +49,14 @@
                     throw new ArgumentException("End_Date cannot be before Start_Date.");
             }
         }
-        public int Owner
+        public int OwnerId
         {
-            get => _owner;
+            get => _ownerId;
             private set
             {
                 if (value <= 0)
                     throw new ArgumentException("Owner must be a positive user ID.");
-                _owner = value;
+                _ownerId = value;
             }
         }
 
@@ -82,7 +82,7 @@
                 Description = description,
                 Start_Date = startDate,
                 End_Date = endDate,
-                Owner = ownerUserId
+                OwnerId = ownerUserId
             };
         }
 
@@ -99,7 +99,7 @@
             _description = description;
             _startDate = startDate;
             _endDate = endDate;
-            _owner = ownerUserId;
+            _ownerId = ownerUserId;
         }
 
         protected Project() { }
@@ -123,7 +123,7 @@
                 ownerUserId
             );
             typeof(Project)
-                .GetProperty(nameof(Project.User))
+                .GetProperty(nameof(Project.Owner))
                 .SetValue(p, ownerUser);
 
             return p;

--- a/synced/synced_DALL/Entities/User.cs
+++ b/synced/synced_DALL/Entities/User.cs
@@ -6,7 +6,7 @@ namespace synced_DALL.Entities
     {
         // ───────────── Backing fields ─────────────
         private string _email;
-        private string _password;
+        private string _passwordHash;
 
         // ───────────── Properties ─────────────
         public int Id { get; private set; }
@@ -26,14 +26,14 @@ namespace synced_DALL.Entities
             }
         }
 
-        public string Password
+        public string PasswordHash
         {
-            get => _password;
+            get => _passwordHash;
             private set
             {
                 if (string.IsNullOrWhiteSpace(value))
-                    throw new ArgumentException("Password cannot be empty.");
-                _password = value;
+                    throw new ArgumentException("Password hash cannot be empty.");
+                _passwordHash = value;
             }
         }
 
@@ -60,7 +60,7 @@ namespace synced_DALL.Entities
                 Firstname = firstname?.Trim(),
                 Lastname = lastname?.Trim(),
                 Email = email,
-                Password = password,
+                PasswordHash = HashPassword(password),
                 CreatedAt = DateTime.UtcNow
             };
         }
@@ -72,7 +72,7 @@ namespace synced_DALL.Entities
             string firstname,
             string lastname,
             string email,
-            string password,
+            string passwordHash,
             DateTime createdAt)
         {
             Id = id;
@@ -80,7 +80,7 @@ namespace synced_DALL.Entities
             Firstname = firstname;
             Lastname = lastname;
             _email = email;
-            _password = password;
+            _passwordHash = passwordHash;
             CreatedAt = createdAt;
         }
 
@@ -93,13 +93,13 @@ namespace synced_DALL.Entities
            string firstname,
            string lastname,
            string email,
-           string password,
+           string passwordHash,
            DateTime createdAt)
         {
             User u = new User
             {
                 _email = email,
-                _password = password,
+                _passwordHash = passwordHash,
                 Username = username,
                 Firstname = firstname,
                 Lastname = lastname,
@@ -112,7 +112,14 @@ namespace synced_DALL.Entities
         public bool VerifyPassword(string attempt)
         {
             if (attempt == null) return false;
-            return attempt == Password;
+            return HashPassword(attempt) == PasswordHash;
+        }
+
+        private static string HashPassword(string password)
+        {
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            var bytes = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(password));
+            return Convert.ToBase64String(bytes);
         }
     }
 }

--- a/synced/synced_DALL/Repositories/ProjectRepository.cs
+++ b/synced/synced_DALL/Repositories/ProjectRepository.cs
@@ -98,7 +98,7 @@ namespace synced_DALL.Repositories
                     },
                     new SqlParameter("@StartDate", SqlDbType.Date) { Value = project.Start_Date },
                     new SqlParameter("@EndDate", SqlDbType.Date) { Value = project.End_Date },
-                    new SqlParameter("@Owner", SqlDbType.Int) { Value = project.Owner }
+                      new SqlParameter("@Owner", SqlDbType.Int) { Value = project.OwnerId }
                 };
 
                 return await _dbHelper.ExecuteScalar<int>(query, parameters);

--- a/synced/synced_DALL/Repositories/UserRepository.cs
+++ b/synced/synced_DALL/Repositories/UserRepository.cs
@@ -50,7 +50,7 @@ namespace synced_DAL.Repositories
                                        ? null
                                        : reader.GetString(reader.GetOrdinal("lastname"));
                     string mail = reader.GetString(reader.GetOrdinal("email"));
-                    string password = reader.GetString(reader.GetOrdinal("password"));
+                    string passwordHash = reader.GetString(reader.GetOrdinal("password"));
                     DateTime created = reader.GetDateTime(reader.GetOrdinal("created_at"));
 
                     return new User(
@@ -59,7 +59,7 @@ namespace synced_DAL.Repositories
                         firstname,
                         lastname,
                         mail,
-                        password,
+                        passwordHash,
                         created
                     );
                 });
@@ -105,7 +105,7 @@ namespace synced_DAL.Repositories
                     new SqlParameter("@Firstname", SqlDbType.VarChar) { Value = user.Firstname ?? (object)DBNull.Value },
                     new SqlParameter("@Lastname", SqlDbType.VarChar) { Value = user.Lastname ?? (object)DBNull.Value },
                     new SqlParameter("@Email", SqlDbType.VarChar) { Value = user.Email },
-                    new SqlParameter("@Password", SqlDbType.VarChar) { Value = user.Password },
+                      new SqlParameter("@Password", SqlDbType.VarChar) { Value = user.PasswordHash },
                     new SqlParameter("@CreatedAt", SqlDbType.DateTime) { Value = user.CreatedAt }
                 };
 

--- a/synced/synced_tests/ProjectTests.cs
+++ b/synced/synced_tests/ProjectTests.cs
@@ -34,8 +34,8 @@ namespace synced_tests
             int userId = 1;
             var projects = new List<Project>
             {
-                new Project { Id = 1, Name = "Project1", Description = "Desc1", Start_Date = DateOnly.FromDateTime(DateTime.Now), Owner = userId },
-                new Project { Id = 2, Name = "Project2", Description = "Desc2", Start_Date = DateOnly.FromDateTime(DateTime.Now), Owner = userId }
+                new Project { Id = 1, Name = "Project1", Description = "Desc1", Start_Date = DateOnly.FromDateTime(DateTime.Now), OwnerId = userId },
+                new Project { Id = 2, Name = "Project2", Description = "Desc2", Start_Date = DateOnly.FromDateTime(DateTime.Now), OwnerId = userId }
             };
 
             _projectRepoMock.Setup(repo => repo.GetAllAsync(userId)).ReturnsAsync(projects);
@@ -60,7 +60,7 @@ namespace synced_tests
                 Description = "Beschrijving",
                 Start_Date = DateOnly.FromDateTime(DateTime.Today),
                 End_Date = DateOnly.FromDateTime(DateTime.Today.AddDays(30)),
-                Owner = 1
+                OwnerId = 1
             };
 
             var mappedProject = new Project
@@ -69,7 +69,7 @@ namespace synced_tests
                 Description = projectDto.Description,
                 Start_Date = projectDto.Start_Date,
                 End_Date = projectDto.End_Date,
-                Owner = projectDto.Owner
+                OwnerId = projectDto.OwnerId
             };
 
             int fakeProjectId = 42;
@@ -96,7 +96,7 @@ namespace synced_tests
                 Description = "Test Beschrijving",
                 Start_Date = DateOnly.FromDateTime(DateTime.Today),
                 End_Date = DateOnly.FromDateTime(DateTime.Today.AddDays(10)),
-                Owner = 1
+                OwnerId = 1
             };
 
             _projectRepoMock.Setup(x => x.CreateAsync(It.IsAny<Project>())).ReturnsAsync(0); // Simuleer mislukking

--- a/synced/synced_tests/ProjectUserTests.cs
+++ b/synced/synced_tests/ProjectUserTests.cs
@@ -147,7 +147,7 @@ namespace synced_tests
                 Firstname = "First",
                 Lastname = "User",
                 Email = "user1@example.com",
-                Password = "password123",
+                PasswordHash = "password123",
                 CreatedAt = DateTime.Now
             },
             Role = Roles.member
@@ -165,7 +165,7 @@ namespace synced_tests
                     Firstname = "Second",
                     Lastname = "User",
                     Email = "user2@example.com",
-                    Password = "password123",
+                    PasswordHash = "password123",
                     CreatedAt = DateTime.Now
                 },
                 Role = Roles.admin


### PR DESCRIPTION
## Summary
- rename Project Owner to `OwnerId` and `Owner`
- hash user passwords and verify using SHA256
- stop exposing user password hashes in project user listing
- update pages, services and tests for new names

## Testing
- `dotnet test synced.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adc04df388329a196aed8089bd75e