### PR TITLE
Fix async delete and adjust unit tests for rich model usage

### DIFF
--- a/synced/synced_BBL/Services/TaskService.cs
+++ b/synced/synced_BBL/Services/TaskService.cs
@@ -137,7 +137,7 @@ namespace synced_BBL.Services
         {
             try
             {
-                bool deleted = _taskRepository.DeleteAsync(id);
+                bool deleted = await _taskRepository.DeleteAsync(id);
 
                 return deleted
                     ? OperationResult<bool>.Success(true)

--- a/synced/synced_DALL/Entities/Project.cs
+++ b/synced/synced_DALL/Entities/Project.cs
@@ -86,6 +86,19 @@
             };
         }
 
+        public static Project FromExisting(
+            int id,
+            string name,
+            string description,
+            DateOnly startDate,
+            DateOnly endDate,
+            int ownerUserId)
+        {
+            var project = Create(name, description, startDate, endDate, ownerUserId);
+            typeof(Project).GetProperty(nameof(Id))!.SetValue(project, id);
+            return project;
+        }
+
         internal Project(
             int id,
             string name,

--- a/synced/synced_DALL/Interfaces/ITaskRepository.cs
+++ b/synced/synced_DALL/Interfaces/ITaskRepository.cs
@@ -17,7 +17,7 @@ namespace synced_DALL.Interfaces
 
         Task<int> UpdateAsync(Task task);
 
-        bool DeleteAsync(int id);
+        Task<bool> DeleteAsync(int id);
     }
 }
 

--- a/synced/synced_DALL/Repositories/TaskRepository.cs
+++ b/synced/synced_DALL/Repositories/TaskRepository.cs
@@ -44,7 +44,7 @@ namespace synced_DALL.Repositories
             }
         }
 
-        public bool DeleteAsync(int id)
+        public async Task<bool> DeleteAsync(int id)
         {
             try
             {
@@ -54,7 +54,7 @@ namespace synced_DALL.Repositories
                     new SqlParameter("@TaskId", SqlDbType.Int) { Value = id }
                 };
 
-                int rowsAffected = _dbHelper.ExecuteNonQuery(query, parameters).Result;
+                int rowsAffected = await _dbHelper.ExecuteNonQuery(query, parameters);
                 return rowsAffected > 0;
             }
             catch (SqlException ex)

--- a/synced/synced_tests/ProjectTests.cs
+++ b/synced/synced_tests/ProjectTests.cs
@@ -34,8 +34,22 @@ namespace synced_tests
             int userId = 1;
             var projects = new List<Project>
             {
-                new Project { Id = 1, Name = "Project1", Description = "Desc1", Start_Date = DateOnly.FromDateTime(DateTime.Now), Owner = userId },
-                new Project { Id = 2, Name = "Project2", Description = "Desc2", Start_Date = DateOnly.FromDateTime(DateTime.Now), Owner = userId }
+                Project.FromExisting(
+                    1,
+                    "Project1",
+                    "Desc1",
+                    DateOnly.FromDateTime(DateTime.Now),
+                    DateOnly.FromDateTime(DateTime.Now),
+                    userId
+                ),
+                Project.FromExisting(
+                    2,
+                    "Project2",
+                    "Desc2",
+                    DateOnly.FromDateTime(DateTime.Now),
+                    DateOnly.FromDateTime(DateTime.Now),
+                    userId
+                )
             };
 
             _projectRepoMock.Setup(repo => repo.GetAllAsync(userId)).ReturnsAsync(projects);
@@ -63,14 +77,13 @@ namespace synced_tests
                 Owner = 1
             };
 
-            var mappedProject = new Project
-            {
-                Name = projectDto.Name,
-                Description = projectDto.Description,
-                Start_Date = projectDto.Start_Date,
-                End_Date = projectDto.End_Date,
-                Owner = projectDto.Owner
-            };
+            var mappedProject = Project.Create(
+                projectDto.Name,
+                projectDto.Description,
+                projectDto.Start_Date,
+                projectDto.End_Date,
+                projectDto.Owner
+            );
 
             int fakeProjectId = 42;
 

--- a/synced/synced_tests/TaskTests.cs
+++ b/synced/synced_tests/TaskTests.cs
@@ -28,33 +28,36 @@ namespace synced_tests
             // Arrange
             var tasks = new List<Task>
             {
-                new Task
-                {
-                    Id = 1,
-                    Title = "Task 1",
-                    Status = Status.todo,
-                    Priority = Priorities.medium,
-                    Deadline = DateTime.Now,
-                    ProjectId = 1
-                },
-                new Task
-                {
-                    Id = 2,
-                    Title = "Task 2",
-                    Status = Status.inprogress,
-                    Priority = Priorities.high,
-                    Deadline = DateTime.Now.AddDays(1),
-                    ProjectId = 1
-                },
-                new Task
-                {
-                    Id = 3,
-                    Title = "Task 3",
-                    Status = Status.done,
-                    Priority = Priorities.low,
-                    Deadline = DateTime.Now.AddDays(-1),
-                    ProjectId = 1
-                }
+                Task.FromExisting(
+                    1,
+                    "Task 1",
+                    "",
+                    Status.todo,
+                    Priorities.medium,
+                    DateTime.Now,
+                    null,
+                    1
+                ),
+                Task.FromExisting(
+                    2,
+                    "Task 2",
+                    "",
+                    Status.inprogress,
+                    Priorities.high,
+                    DateTime.Now.AddDays(1),
+                    null,
+                    1
+                ),
+                Task.FromExisting(
+                    3,
+                    "Task 3",
+                    "",
+                    Status.done,
+                    Priorities.low,
+                    DateTime.Now.AddDays(-1),
+                    null,
+                    1
+                )
             };
 
             // Setup mock to return the tasks
@@ -101,17 +104,16 @@ namespace synced_tests
                 UserId = 1
             };
 
-            var newTask = new Task
-            {
-                Id = 1,
-                Title = taskDto.Title,
-                Description = taskDto.Description,
-                Status = taskDto.Status,
-                Priority = taskDto.Priority,
-                Deadline = taskDto.Deadline,
-                ProjectId = taskDto.ProjectId,
-                UserId = taskDto.UserId
-            };
+            var newTask = Task.FromExisting(
+                1,
+                taskDto.Title,
+                taskDto.Description,
+                taskDto.Status,
+                taskDto.Priority,
+                taskDto.Deadline,
+                taskDto.UserId,
+                taskDto.ProjectId
+            );
 
             _taskRepoMock.Setup(x => x.CreateAsync(It.IsAny<Task>())).ReturnsAsync(1); 
 
@@ -166,17 +168,16 @@ namespace synced_tests
                 UserId = 1
             };
 
-            var updatedTask = new Task
-            {
-                Id = taskDto.Id,
-                Title = taskDto.Title,
-                Description = taskDto.Description,
-                Status = taskDto.Status,
-                Priority = taskDto.Priority,
-                Deadline = taskDto.Deadline,
-                ProjectId = taskDto.ProjectId,
-                UserId = taskDto.UserId,
-            };
+            var updatedTask = Task.FromExisting(
+                taskDto.Id,
+                taskDto.Title,
+                taskDto.Description,
+                taskDto.Status,
+                taskDto.Priority,
+                taskDto.Deadline,
+                taskDto.UserId,
+                taskDto.ProjectId
+            );
 
             _taskRepoMock.Setup(x => x.UpdateAsync(It.IsAny<Task>())).ReturnsAsync(1);  // Simuleer succes
 
@@ -218,7 +219,7 @@ namespace synced_tests
         public async System.Threading.Tasks.Task DeleteTask_ReturnsSuccess_WhenTaskIsDeleted()
         {
             int taskId = 1;
-            _taskRepoMock.Setup(x => x.DeleteAsync(taskId)).Returns(true);
+            _taskRepoMock.Setup(x => x.DeleteAsync(taskId)).ReturnsAsync(true);
 
             var result = await _taskService.DeleteTask(taskId);
 
@@ -230,7 +231,7 @@ namespace synced_tests
         public async System.Threading.Tasks.Task DeleteTask_ReturnsFailure_WhenTaskNotFound()
         {
             int taskId = 1;
-            _taskRepoMock.Setup(x => x.DeleteAsync(taskId)).Returns(false);
+            _taskRepoMock.Setup(x => x.DeleteAsync(taskId)).ReturnsAsync(false);
 
             var result = await _taskService.DeleteTask(taskId);
 

--- a/synced/synced_tests/UserTests.cs
+++ b/synced/synced_tests/UserTests.cs
@@ -88,8 +88,8 @@ namespace synced_tests
             string plain = "mypassword";
             var user = User.Create("u", "f", "l", "email@example.com", plain);
 
-            Assert.NotEqual(plain, user.Password); // wacht dat wachtwoord gehasht is
-            Assert.False(string.IsNullOrWhiteSpace(user.Password));
+            Assert.NotEqual(plain, user.PasswordHash);
+            Assert.False(string.IsNullOrWhiteSpace(user.PasswordHash));
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace synced_tests
             string plain = "plain";
             var user = User.Create("u", "f", "l", "email@example.com", plain);
 
-            Assert.NotEqual(plain, user.Password); // controleer dat wachtwoord niet in plain text wordt opgeslagen
+            Assert.NotEqual(plain, user.PasswordHash);
         }
     }
 }


### PR DESCRIPTION
## Summary
- make `ITaskRepository.DeleteAsync` return a `Task<bool>` and update `TaskRepository` implementation
- call the async delete method in `TaskService`
- add `Project.FromExisting` helper for creating instances with an id
- update unit tests to use rich entity factories and hashed password property